### PR TITLE
Todo 表示の session.todo() API 移行

### DIFF
--- a/src/chat-view-provider.ts
+++ b/src/chat-view-provider.ts
@@ -11,6 +11,7 @@ import type {
   Provider,
   ProviderListResult,
   Session,
+  Todo,
 } from "./opencode-client";
 
 // --- File attachment ---
@@ -38,7 +39,8 @@ export type ExtToWebviewMessage =
   | { type: "toolConfig"; paths: OpenCodePath }
   | { type: "locale"; vscodeLanguage: string }
   | { type: "modelUpdated"; model: string; default: Record<string, string> }
-  | { type: "sessionDiff"; sessionId: string; diffs: FileDiff[] };
+  | { type: "sessionDiff"; sessionId: string; diffs: FileDiff[] }
+  | { type: "sessionTodos"; sessionId: string; todos: Todo[] };
 
 // --- Webview → Extension Host ---
 export type WebviewToExtMessage =
@@ -74,6 +76,7 @@ export type WebviewToExtMessage =
   | { type: "openTerminal" }
   | { type: "setModel"; model: string }
   | { type: "getSessionDiff"; sessionId: string }
+  | { type: "getSessionTodos"; sessionId: string }
   | { type: "openDiffEditor"; filePath: string; before: string; after: string }
   | { type: "ready" };
 
@@ -333,6 +336,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       case "getSessionDiff": {
         const diffs = await this.connection.getSessionDiff(message.sessionId);
         this.postMessage({ type: "sessionDiff", sessionId: message.sessionId, diffs });
+        break;
+      }
+      case "getSessionTodos": {
+        const todos = await this.connection.getSessionTodos(message.sessionId);
+        this.postMessage({ type: "sessionTodos", sessionId: message.sessionId, todos });
         break;
       }
       case "openDiffEditor": {

--- a/src/opencode-client.ts
+++ b/src/opencode-client.ts
@@ -12,11 +12,12 @@ import {
   type Part,
   type Provider,
   type Session,
+  type Todo,
   type ToolListItem,
 } from "@opencode-ai/sdk";
 import * as vscode from "vscode";
 
-export type { Event, Session, Message, Part, Provider, McpStatus, ToolListItem, Config, OpenCodePath, FileDiff };
+export type { Event, Session, Message, Part, Provider, McpStatus, ToolListItem, Config, OpenCodePath, FileDiff, Todo };
 
 // provider.list() が返す生データ型
 export type ProviderListResult = {
@@ -244,6 +245,16 @@ export class OpenCodeConnection {
       path: { id: sessionId, permissionID: permissionId },
       body: { response },
     });
+  }
+
+  // --- Session Todo API ---
+
+  async getSessionTodos(sessionId: string): Promise<Todo[]> {
+    const client = this.requireClient();
+    const response = await client.session.todo({
+      path: { id: sessionId },
+    });
+    return response.data!;
   }
 
   // --- Session Diff API ---

--- a/webview/__tests__/hooks/useMessages.test.ts
+++ b/webview/__tests__/hooks/useMessages.test.ts
@@ -18,12 +18,6 @@ describe("useMessages", () => {
       expect(result.current.inputTokens).toBe(0);
     });
 
-    // latestTodos is empty
-    it("latestTodos が空配列であること", () => {
-      const { result } = renderHook(() => useMessages());
-      expect(result.current.latestTodos).toEqual([]);
-    });
-
     // prefillText is empty
     it("prefillText が空文字であること", () => {
       const { result } = renderHook(() => useMessages());
@@ -236,34 +230,6 @@ describe("useMessages", () => {
       } as unknown as Event;
       act(() => result.current.handleMessageEvent(event));
       expect(result.current.isShellMessage("m1")).toBe(false);
-    });
-  });
-
-  // latestTodos derivation
-  context("messages に todowrite ツールの完了出力がある場合", () => {
-    // parses todos from completed tool output
-    it("latestTodos にパース結果を返すこと", () => {
-      const { result } = renderHook(() => useMessages());
-      const msgs: MessageWithParts[] = [
-        {
-          info: { id: "m1" } as any,
-          parts: [
-            {
-              id: "p1",
-              messageID: "m1",
-              type: "tool",
-              tool: "todowrite",
-              state: {
-                status: "completed",
-                output: JSON.stringify([{ content: "task1", status: "done" }]),
-                input: {},
-              },
-            } as any,
-          ],
-        },
-      ];
-      act(() => result.current.setMessages(msgs));
-      expect(result.current.latestTodos).toEqual([{ content: "task1", status: "done" }]);
     });
   });
 });

--- a/webview/__tests__/scenarios/11-todo.test.tsx
+++ b/webview/__tests__/scenarios/11-todo.test.tsx
@@ -1,45 +1,25 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
-import { createMessage, createSession } from "../factories";
+import { createEvent, createSession } from "../factories";
 import { renderApp, sendExtMessage } from "../helpers";
 
-/** todowrite ツール出力付きのセッションをセットアップする */
-async function setupWithTodos(todos: Array<{ content: string; status: string; priority?: string }>) {
+/** session.todo() API 経由で Todo 付きのセッションをセットアップする */
+async function setupWithTodos(todos: Array<{ id: string; content: string; status: string; priority: string }>) {
   renderApp();
   await sendExtMessage({ type: "activeSession", session: createSession({ id: "s1" }) });
-
-  const msg = createMessage({ id: "m1", sessionID: "s1", role: "assistant" });
-  const todoPart = {
-    id: "tp1",
-    type: "tool" as const,
-    tool: "todowrite",
-    messageID: "m1",
-    time: { created: Date.now(), updated: Date.now() },
-    state: {
-      status: "completed",
-      title: "todowrite",
-      input: { todos },
-      output: JSON.stringify(todos),
-    },
-  };
-
-  await sendExtMessage({
-    type: "messages",
-    sessionId: "s1",
-    messages: [{ info: msg, parts: [todoPart as any] }],
-  });
+  await sendExtMessage({ type: "sessionTodos", sessionId: "s1", todos });
 }
 
 // Todo
 describe("Todo", () => {
-  // TodoHeader is shown from todowrite output
-  context("todowrite 出力から TodoHeader を表示した場合", () => {
+  // TodoHeader is shown from session.todo() API
+  context("session.todo() API から TodoHeader を表示した場合", () => {
     beforeEach(async () => {
       await setupWithTodos([
-        { content: "First task", status: "completed" },
-        { content: "Second task", status: "in-progress" },
-        { content: "Third task", status: "pending" },
+        { id: "t1", content: "First task", status: "completed", priority: "medium" },
+        { id: "t2", content: "Second task", status: "in_progress", priority: "medium" },
+        { id: "t3", content: "Third task", status: "pending", priority: "low" },
       ]);
     });
 
@@ -58,8 +38,8 @@ describe("Todo", () => {
   context("Todo 一覧を展開した場合", () => {
     beforeEach(async () => {
       await setupWithTodos([
-        { content: "Implement feature", status: "completed" },
-        { content: "Write tests", status: "in-progress", priority: "high" },
+        { id: "t1", content: "Implement feature", status: "completed", priority: "medium" },
+        { id: "t2", content: "Write tests", status: "in_progress", priority: "high" },
       ]);
 
       const user = userEvent.setup();
@@ -87,37 +67,25 @@ describe("Todo", () => {
     renderApp();
     await sendExtMessage({ type: "activeSession", session: createSession({ id: "s1" }) });
 
-    // メッセージなし → TodoHeader なし
+    // Todo なし → TodoHeader なし
     expect(screen.queryByText("To Do")).not.toBeInTheDocument();
   });
 
-  // Todos are also shown from todoread tool output
-  it("todoread ツールの出力からも Todo が表示されること", async () => {
+  // todo.updated SSE event updates TodoHeader in real-time
+  it("todo.updated SSE イベントで TodoHeader がリアルタイム更新されること", async () => {
     renderApp();
     await sendExtMessage({ type: "activeSession", session: createSession({ id: "s1" }) });
 
-    const msg = createMessage({ id: "m1", sessionID: "s1", role: "assistant" });
-    const todoPart = {
-      id: "tp1",
-      type: "tool" as const,
-      tool: "todoread",
-      messageID: "m1",
-      time: { created: Date.now(), updated: Date.now() },
-      state: {
-        status: "completed",
-        title: "todoread",
-        input: {},
-        output: JSON.stringify([
-          { content: "Read task 1", status: "completed" },
-          { content: "Read task 2", status: "pending" },
-        ]),
-      },
-    };
-
+    // todo.updated イベントで Todo を受信
     await sendExtMessage({
-      type: "messages",
-      sessionId: "s1",
-      messages: [{ info: msg, parts: [todoPart as any] }],
+      type: "event",
+      event: createEvent("todo.updated", {
+        sessionID: "s1",
+        todos: [
+          { id: "t1", content: "SSE task 1", status: "completed", priority: "medium" },
+          { id: "t2", content: "SSE task 2", status: "pending", priority: "low" },
+        ],
+      }),
     });
 
     expect(screen.getByText("1/2")).toBeInTheDocument();
@@ -126,10 +94,53 @@ describe("Todo", () => {
   // Count matches when all todos are completed
   it("全て完了のとき件数が一致すること", async () => {
     await setupWithTodos([
-      { content: "Task A", status: "completed" },
-      { content: "Task B", status: "done" },
+      { id: "t1", content: "Task A", status: "completed", priority: "medium" },
+      { id: "t2", content: "Task B", status: "completed", priority: "low" },
     ]);
 
     expect(screen.getByText("2/2")).toBeInTheDocument();
+  });
+
+  // Todos are cleared when switching to a session without todos
+  it("セッション切替で Todo がクリアされること", async () => {
+    await setupWithTodos([{ id: "t1", content: "Some task", status: "pending", priority: "medium" }]);
+    expect(screen.getByText("To Do")).toBeInTheDocument();
+
+    // 別のセッション（Todo なし）に切替
+    await sendExtMessage({ type: "activeSession", session: createSession({ id: "s2" }) });
+    // 新セッションの sessionTodos 応答（空）でクリアされる
+    await sendExtMessage({ type: "sessionTodos", sessionId: "s2", todos: [] });
+
+    expect(screen.queryByText("To Do")).not.toBeInTheDocument();
+  });
+
+  // todo.updated for a different session is ignored
+  it("別セッションの todo.updated イベントは無視されること", async () => {
+    renderApp();
+    await sendExtMessage({ type: "activeSession", session: createSession({ id: "s1" }) });
+
+    // 別セッション (s999) の todo.updated
+    await sendExtMessage({
+      type: "event",
+      event: createEvent("todo.updated", {
+        sessionID: "s999",
+        todos: [{ id: "t1", content: "Other session task", status: "pending", priority: "medium" }],
+      }),
+    });
+
+    expect(screen.queryByText("To Do")).not.toBeInTheDocument();
+  });
+
+  // Todos are preserved when activeSession message is re-sent for the same session
+  it("同じセッションの activeSession 再送で Todo がクリアされないこと", async () => {
+    await setupWithTodos([{ id: "t1", content: "Persistent task", status: "pending", priority: "medium" }]);
+    expect(screen.getByText("To Do")).toBeInTheDocument();
+
+    // 同じセッション s1 の activeSession が再送される（session.updated 等で発生しうる）
+    await sendExtMessage({ type: "activeSession", session: createSession({ id: "s1" }) });
+
+    // Todo はクリアされず維持される
+    expect(screen.getByText("To Do")).toBeInTheDocument();
+    expect(screen.getByText("0/1")).toBeInTheDocument();
   });
 });

--- a/webview/components/molecules/TodoHeader/TodoHeader.tsx
+++ b/webview/components/molecules/TodoHeader/TodoHeader.tsx
@@ -1,13 +1,13 @@
+import type { Todo } from "@opencode-ai/sdk";
 import { useState } from "react";
 import { useLocale } from "../../../locales";
-import type { TodoItem } from "../../../utils/todo";
 import { CheckboxIcon, ChevronRightIcon } from "../../atoms/icons";
 import type { BadgeVariant } from "../../atoms/StatusItem";
 import { StatusItem } from "../../atoms/StatusItem";
 import styles from "./TodoHeader.module.css";
 
 type Props = {
-  todos: TodoItem[];
+  todos: Todo[];
 };
 
 export function TodoHeader({ todos }: Props) {

--- a/webview/contexts/AppContext.tsx
+++ b/webview/contexts/AppContext.tsx
@@ -1,8 +1,7 @@
-import type { FileDiff, Permission, Provider, Session } from "@opencode-ai/sdk";
+import type { FileDiff, Permission, Provider, Session, Todo } from "@opencode-ai/sdk";
 import { createContext, useContext } from "react";
 import type { MessageWithParts } from "../hooks/useMessages";
 import type { LocaleSetting } from "../locales";
-import type { TodoItem } from "../utils/todo";
 import type { AllProvidersData, FileAttachment } from "../vscode-api";
 
 export type AppContextValue = {
@@ -19,7 +18,7 @@ export type AppContextValue = {
   // Messages
   messages: MessageWithParts[];
   inputTokens: number;
-  latestTodos: TodoItem[];
+  latestTodos: Todo[];
   prefillText: string;
   onPrefillConsumed: () => void;
 

--- a/webview/hooks/useMessages.ts
+++ b/webview/hooks/useMessages.ts
@@ -1,7 +1,5 @@
 import type { Event, Message, Part } from "@opencode-ai/sdk";
 import { useCallback, useMemo, useRef, useState } from "react";
-import type { TodoItem } from "../utils/todo";
-import { parseTodos } from "../utils/todo";
 
 export type MessageWithParts = { info: Message; parts: Part[] };
 
@@ -75,31 +73,6 @@ export function useMessages() {
     return total;
   }, [messages]);
 
-  // メッセージから最新の ToDo リストを導出（todowrite/todoread ツールの最新の出力）
-  const latestTodos = useMemo<TodoItem[]>(() => {
-    for (let mi = messages.length - 1; mi >= 0; mi--) {
-      const parts = messages[mi].parts;
-      for (let pi = parts.length - 1; pi >= 0; pi--) {
-        const p = parts[pi];
-        if (p.type !== "tool") continue;
-        if (p.tool !== "todowrite" && p.tool !== "todoread") continue;
-        const st = p.state;
-        if (st.status === "completed" && st.output) {
-          const parsed = parseTodos(st.output);
-          if (parsed) return parsed;
-        }
-        if (st.status !== "pending") {
-          const input = st.input as Record<string, unknown> | undefined;
-          if (input) {
-            const parsed = parseTodos(input.todos ?? input);
-            if (parsed) return parsed;
-          }
-        }
-      }
-    }
-    return [];
-  }, [messages]);
-
   const consumePrefill = useCallback(() => {
     setPrefillText("");
   }, []);
@@ -138,7 +111,6 @@ export function useMessages() {
     prefillText,
     setPrefillText,
     inputTokens,
-    latestTodos,
     consumePrefill,
     handleMessageEvent,
     markPendingShell,

--- a/webview/vscode-api.ts
+++ b/webview/vscode-api.ts
@@ -3,7 +3,7 @@
  * Extension Host 側の chat-view-provider.ts で定義したプロトコルに対応する。
  */
 
-import type { Event, FileDiff, Message, Part, Provider, Session } from "@opencode-ai/sdk";
+import type { Event, FileDiff, Message, Part, Provider, Session, Todo } from "@opencode-ai/sdk";
 
 // --- File attachment ---
 export type FileAttachment = {
@@ -66,7 +66,8 @@ export type ExtToWebviewMessage =
   | { type: "toolConfig"; paths: { home: string; config: string; state: string; directory: string } }
   | { type: "locale"; vscodeLanguage: string }
   | { type: "modelUpdated"; model: string; default: Record<string, string> }
-  | { type: "sessionDiff"; sessionId: string; diffs: FileDiff[] };
+  | { type: "sessionDiff"; sessionId: string; diffs: FileDiff[] }
+  | { type: "sessionTodos"; sessionId: string; todos: Todo[] };
 
 // --- Webview → Extension Host ---
 export type WebviewToExtMessage =
@@ -102,6 +103,7 @@ export type WebviewToExtMessage =
   | { type: "openTerminal" }
   | { type: "setModel"; model: string }
   | { type: "getSessionDiff"; sessionId: string }
+  | { type: "getSessionTodos"; sessionId: string }
   | { type: "openDiffEditor"; filePath: string; before: string; after: string }
   | { type: "ready" };
 


### PR DESCRIPTION
## 概要

Todo 表示のデータソースを、メッセージストリームからの `todowrite`/`todoread` ツールパート逆順パースから、専用の `session.todo()` SDK API + `todo.updated` SSE イベントに移行する。

Closes #15

## 背景

従来は `useMessages` フック内で全メッセージを末尾から走査し、`todowrite`/`todoread` ツールパートの出力を `parseTodos()` でパースして Todo リストを導出していた。`session.todo()` API はセッションの Todo リストを直接取得する専用エンドポイントであり、パースロジックを回避してより信頼性の高い方法で Todo を取得できる。

## 変更内容

### Extension Host 側
- `opencode-client.ts`: `Todo` 型の re-export、`getSessionTodos()` メソッド追加
- `chat-view-provider.ts`: `getSessionTodos` / `sessionTodos` メッセージプロトコル追加

### Webview 側
- `vscode-api.ts`: `sessionTodos` (Ext→Webview) / `getSessionTodos` (Webview→Ext) メッセージ型追加
- `App.tsx`: `todos` state 追加、`todo.updated` SSE イベントハンドリング、セッション切替時の Todo フェッチ
- `useMessages.ts`: `latestTodos` の useMemo 導出ロジックと `parseTodos` import を削除
- `AppContext.tsx`: `latestTodos` の型を `TodoItem` → SDK `Todo` に変更
- `TodoHeader.tsx`: Props 型を SDK `Todo` に変更

### テスト
- `11-todo.test.tsx`: `sessionTodos` メッセージと `todo.updated` SSE イベントベースのテストに書き換え。セッション切替クリア・別セッション無視・`activeSession` 再送時の維持テストを追加
- `useMessages.test.ts`: 削除された `latestTodos` 関連テスト 2 件を除去

### 後方互換性
- `TodoView`（ツールパート内のインライン表示）と `parseTodos` ユーティリティは変更なし

## チェックリスト

- [x] `npm run build` パス
- [x] `npm test` パス（52 ファイル / 710 テスト）
- [x] Biome lint エラー 0
