### PR TITLE
リポジトリ名を opencode-gui に変更するための URL 更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,5 +40,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Todo display
 - i18n support (English, Japanese)
 
-[Unreleased]: https://github.com/ktmage/OpenCodeGUI/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/ktmage/OpenCodeGUI/releases/tag/v0.1.0
+[Unreleased]: https://github.com/ktmage/opencode-gui/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ktmage/opencode-gui/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ This project itself is developed primarily through AI-assisted coding, and we we
 #### Setup
 
 ```sh
-git clone https://github.com/<your-fork>/OpenCodeGUI.git
-cd OpenCodeGUI
+git clone https://github.com/<your-fork>/opencode-gui.git
+cd opencode-gui
 npm install
 npm run build
 ```
@@ -45,7 +45,7 @@ npm test
 
 #### Reporting Bugs / Requesting Features
 
-Opening an issue before starting work is recommended. Use the provided [issue templates](https://github.com/ktmage/OpenCodeGUI/issues/new/choose).
+Opening an issue before starting work is recommended. Use the provided [issue templates](https://github.com/ktmage/opencode-gui/issues/new/choose).
 
 For small fixes (typos, documentation improvements), you may open a PR directly.
 
@@ -112,8 +112,8 @@ By submitting a pull request, you agree that your contributions are licensed und
 #### セットアップ
 
 ```sh
-git clone https://github.com/<your-fork>/OpenCodeGUI.git
-cd OpenCodeGUI
+git clone https://github.com/<your-fork>/opencode-gui.git
+cd opencode-gui
 npm install
 npm run build
 ```
@@ -128,7 +128,7 @@ npm test
 
 #### バグ報告・機能リクエスト
 
-作業を開始する前に Issue を立てることを推奨します。[Issue テンプレート](https://github.com/ktmage/OpenCodeGUI/issues/new/choose)を利用してください。
+作業を開始する前に Issue を立てることを推奨します。[Issue テンプレート](https://github.com/ktmage/opencode-gui/issues/new/choose)を利用してください。
 
 小さな修正（typo、ドキュメント改善など）は直接 PR を出しても構いません。
 

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ktmage/OpenCodeGUI"
+    "url": "https://github.com/ktmage/opencode-gui"
   },
-  "homepage": "https://github.com/ktmage/OpenCodeGUI#readme",
+  "homepage": "https://github.com/ktmage/opencode-gui#readme",
   "bugs": {
-    "url": "https://github.com/ktmage/OpenCodeGUI/issues"
+    "url": "https://github.com/ktmage/opencode-gui/issues"
   },
   "keywords": [
     "opencode",


### PR DESCRIPTION
## 概要

Closes #31

GitHub リポジトリ名を `OpenCodeGUI` → `opencode-gui` に変更することに伴い、コード内のリポジトリ URL 参照を更新します。

## 変更内容

- `package.json`: repository / homepage / bugs の URL を更新（3箇所）
- `CHANGELOG.md`: リリース比較・タグ URL を更新（2箇所）
- `CONTRIBUTING.md`: clone URL / cd ディレクトリ名 / Issue テンプレート URL を更新（6箇所）

## 変更しない箇所

以下はプロダクト名・拡張機能 ID としての言及であり、リポジトリ名とは無関係のためそのままにしています。

- `package.json` の `name` (`opencodegui`) — 拡張機能 ID
- `displayName` (`OpenCodeGUI`) — ストア表示名
- `extension.ts` のユーザー向けメッセージ
- `release.yml` の VSIX ファイル名
- README / CONTRIBUTING のタイトル・説明文
- THIRD_PARTY_NOTICES / bug_report テンプレート

## 備考

この PR をマージした後、GitHub Settings > General > Repository name で `opencode-gui` にリネームしてください。
