### PR TITLE
「ターミナルで開く」ボタンのツールチップテキスト改善

### DIFF
--- a/webview/__tests__/scenarios/09-settings.test.tsx
+++ b/webview/__tests__/scenarios/09-settings.test.tsx
@@ -89,7 +89,7 @@ describe("設定", () => {
     await setupForSettings();
     const user = userEvent.setup();
 
-    await user.click(screen.getByTitle("Open in terminal"));
+    await user.click(screen.getByTitle("Open session in terminal"));
 
     expect(postMessage).toHaveBeenCalledWith({ type: "openTerminal" });
   });

--- a/webview/locales/en.ts
+++ b/webview/locales/en.ts
@@ -16,7 +16,7 @@ export const en = {
   "input.remove": "Remove",
   "input.placeholder": "Ask OpenCode... (type # to attach files)",
   "input.addFile": (name: string) => `Add ${name}`,
-  "input.openTerminal": "Open in terminal",
+  "input.openTerminal": "Open session in terminal",
   "input.shellMode": "Shell mode",
   "input.placeholder.shell": "Enter shell command...",
   "input.settings": "Settings",

--- a/webview/locales/ja.ts
+++ b/webview/locales/ja.ts
@@ -18,7 +18,7 @@ export const ja: typeof en = {
   "input.remove": "削除",
   "input.placeholder": "OpenCode に質問... (# でファイルを添付)",
   "input.addFile": (name: string) => `${name} を追加`,
-  "input.openTerminal": "ターミナルで開く",
+  "input.openTerminal": "セッションをターミナルで開く",
   "input.shellMode": "シェルモード",
   "input.placeholder.shell": "シェルコマンドを入力...",
   "input.settings": "設定",


### PR DESCRIPTION
## 概要

「ターミナルで開く」ボタンのツールチップテキストを、実際の動作が伝わる表現に変更。

## 変更内容

- `webview/locales/en.ts`: `"Open in terminal"` → `"Open session in terminal"`
- `webview/locales/ja.ts`: `"ターミナルで開く"` → `"セッションをターミナルで開く"`
- `webview/__tests__/scenarios/09-settings.test.tsx`: テストの `getByTitle` を新テキストに合わせて更新

closes #43