### PR TITLE
feat: ファイル変更一覧にmax-heightを設定しスクロール可能にする

### DIFF
--- a/webview/components/molecules/FileChangesHeader/FileChangesHeader.module.css
+++ b/webview/components/molecules/FileChangesHeader/FileChangesHeader.module.css
@@ -58,6 +58,8 @@
 
 .list {
   padding: 0 8px 6px 12px;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 /* --- File Item --- */


### PR DESCRIPTION
## 概要

ファイル変更一覧（`FileChangesHeader`）の `.list` に `max-height: 300px` と `overflow-y: auto` を追加し、ファイル数が多い場合にスクロール可能にしました。

## 変更内容

- `FileChangesHeader.module.css` の `.list` に `max-height: 300px` と `overflow-y: auto` を追加

## 既存パターンとの統一

| コンポーネント | セレクタ | max-height |
|---|---|---|
| DiffView | `.lines` | 300px |
| ToolPartView | `.output` | 200px |
| **FileChangesHeader** | **`.list`** | **300px** ✅ |

## テスト

- 既存テスト12件すべてパス

Closes #55