### PR TITLE
feat: 入力エリアのテキスト入力部分を縦に拡大し垂直中央揃えにする (#59)

### DIFF
--- a/webview/components/organisms/InputArea/InputArea.module.css
+++ b/webview/components/organisms/InputArea/InputArea.module.css
@@ -33,6 +33,8 @@
 
 .textareaContainer {
   position: relative;
+  display: flex;
+  align-items: center;
 }
 
 .textarea {
@@ -47,7 +49,8 @@
   line-height: 1.4;
   resize: none;
   max-height: 120px;
-  min-height: 20px;
+  min-height: 28px;
+  padding: 2px 0;
 }
 
 .textarea::placeholder {


### PR DESCRIPTION
## 概要

入力エリア（textarea）のテキスト入力部分を縦に拡大し、テキスト・プレースホルダーを垂直中央に揃えるようにしました。

## 変更内容

- `.textareaContainer` に `display: flex; align-items: center;` を追加し、テキストを縦中央に配置
- `.textarea` の `min-height` を `20px` → `28px` に変更し、入力部分を縦に拡大
- `.textarea` に `padding: 2px 0;` を追加し、上下の余白を均等化

## 変更ファイル

- `webview/components/organisms/InputArea/InputArea.module.css`

Closes #59