### PR TITLE
feat: チャット入力で skill を明示選択できるようにする

### DIFF
--- a/packages/agents/opencode/src/__tests__/opencode-agent.test.ts
+++ b/packages/agents/opencode/src/__tests__/opencode-agent.test.ts
@@ -46,6 +46,7 @@ function createMockSdkClient() {
     },
     app: {
       agents: vi.fn().mockResolvedValue({ data: [] }),
+      skills: vi.fn().mockResolvedValue({ data: [] }),
     },
     mcp: {
       status: vi.fn().mockResolvedValue({ data: {} }),
@@ -366,6 +367,17 @@ describe("OpenCodeAgent", () => {
       expect(call.parts[1]).toEqual({ type: "agent", name: "code-reviewer" });
     });
 
+    it("should prepend synthetic skill command when skill is provided", async () => {
+      await agent.connect();
+
+      await agent.sendMessage("sess-1", "Hello", { skill: "coding-guidelines" } as never);
+
+      const call = mockClient.session.promptAsync.mock.calls[0][0];
+      expect(call.parts).toHaveLength(2);
+      expect(call.parts[0]).toEqual({ type: "text", text: "/coding-guidelines", synthetic: true });
+      expect(call.parts[1]).toEqual({ type: "text", text: "Hello" });
+    });
+
     it("should include all parts when files and agent are provided", async () => {
       await agent.connect();
       agent.workspaceFolder = "/ws";
@@ -681,6 +693,22 @@ describe("OpenCodeAgent", () => {
       expect(mockClient.tool.ids).toHaveBeenCalled();
       // mapToolIds wraps each string into { id }
       expect(result).toEqual([{ id: "tool-1" }, { id: "tool-2" }]);
+    });
+  });
+
+  describe("getSkills()", () => {
+    it("should call app.skills() and return mapped skills", async () => {
+      mockClient.app.skills.mockResolvedValue({
+        data: [{ name: "coding-guidelines", description: "desc", location: "/skills/coding-guidelines" }],
+      });
+      await agent.connect();
+
+      const result = await agent.getSkills();
+
+      expect(mockClient.app.skills).toHaveBeenCalled();
+      expect(result).toEqual([
+        { name: "coding-guidelines", description: "desc", location: "/skills/coding-guidelines" },
+      ]);
     });
   });
 

--- a/packages/agents/opencode/src/mappers.ts
+++ b/packages/agents/opencode/src/mappers.ts
@@ -32,6 +32,7 @@ import type {
   McpStatus,
   MessagePart,
   ProviderInfo,
+  SkillInfo,
   TodoItem,
   ToolListItem,
 } from "@opencodegui/core";
@@ -127,6 +128,14 @@ export function mapAgent(agent: Agent): AgentInfo {
 
 export function mapAgents(agents: Agent[]): AgentInfo[] {
   return agents.map(mapAgent);
+}
+
+export function mapSkills(skills: Array<{ name: string; description: string; location: string }>): SkillInfo[] {
+  return skills.map((skill) => ({
+    name: skill.name,
+    description: skill.description,
+    location: skill.location,
+  }));
 }
 
 // ============================================================

--- a/packages/agents/opencode/src/opencode-agent.ts
+++ b/packages/agents/opencode/src/opencode-agent.ts
@@ -29,6 +29,7 @@ import type {
   ProviderInfo,
   QuestionAnswer,
   SendMessageOptions,
+  SkillInfo,
   TodoItem,
   ToolListItem,
 } from "@opencodegui/core";
@@ -44,6 +45,7 @@ import {
   mapProviders,
   mapSession,
   mapSessions,
+  mapSkills,
   mapTodos,
   mapToolIds,
 } from "./mappers";
@@ -239,10 +241,16 @@ export class OpenCodeAgent implements IAgent {
   async sendMessage(sessionId: string, text: string, options?: SendMessageOptions): Promise<void> {
     const client = this.requireClient();
     const parts: Array<
-      | { type: "text"; text: string }
+      | { type: "text"; text: string; synthetic?: boolean }
       | { type: "file"; mime: string; url: string; filename: string }
       | { type: "agent"; name: string }
-    > = [{ type: "text", text }];
+    > = [];
+
+    if (options?.skill) {
+      parts.push({ type: "text", text: `/${options.skill}`, synthetic: true });
+    }
+
+    parts.push({ type: "text", text });
 
     if (options?.files) {
       for (const file of options.files) {
@@ -318,6 +326,12 @@ export class OpenCodeAgent implements IAgent {
     const client = this.requireClient();
     const response = await client.app.agents();
     return mapAgents(response.data!);
+  }
+
+  async getSkills(): Promise<SkillInfo[]> {
+    const client = this.requireClient();
+    const response = await client.app.skills();
+    return mapSkills(response.data!);
   }
 
   async getChildSessions(sessionId: string): Promise<ChatSession[]> {

--- a/packages/core/src/agent.interface.ts
+++ b/packages/core/src/agent.interface.ts
@@ -22,6 +22,7 @@ import type {
   ProviderInfo,
   QuestionAnswer,
   SendMessageOptions,
+  SkillInfo,
   TodoItem,
   ToolListItem,
 } from "./domain";
@@ -100,6 +101,7 @@ export interface IAgent {
 
   // --- Agent list (capabilities.subAgent) ---
   getAgents(): Promise<AgentInfo[]>;
+  getSkills(): Promise<SkillInfo[]>;
   getChildSessions(sessionId: string): Promise<ChatSession[]>;
 
   // --- Permissions (capabilities.permission) ---

--- a/packages/core/src/domain.ts
+++ b/packages/core/src/domain.ts
@@ -438,6 +438,12 @@ export type AgentInfo = {
   color?: string;
 };
 
+export type SkillInfo = {
+  name: string;
+  description?: string;
+  location?: string;
+};
+
 // ============================================================
 // App Config & Paths
 // ============================================================
@@ -460,6 +466,7 @@ export type SendMessageOptions = {
   files?: FileAttachment[];
   agent?: string;
   primaryAgent?: string;
+  skill?: string;
 };
 
 // ============================================================

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -20,6 +20,7 @@ import type {
   PermissionResponse,
   ProviderInfo,
   QuestionAnswer,
+  SkillInfo,
   TodoItem,
 } from "./domain";
 
@@ -59,6 +60,7 @@ export type UIToHostMessage =
       files?: FileAttachment[];
       agent?: string;
       primaryAgent?: string;
+      skill?: string;
     }
   | {
       type: "editAndResend";
@@ -105,6 +107,7 @@ export type UIToHostMessage =
   | { type: "getSessionTodos"; sessionId: string }
   | { type: "getChildSessions"; sessionId: string }
   | { type: "getAgents" }
+  | { type: "getSkills" }
 
   // --- Model config ---
   | { type: "setModel"; model: string }
@@ -193,6 +196,7 @@ export type HostToUIMessage =
 
   // --- Agent list ---
   | { type: "agents"; agents: AgentInfo[] }
+  | { type: "skills"; skills: SkillInfo[] }
 
   // --- Platform data ---
   | { type: "openEditors"; files: FileAttachment[] }

--- a/packages/platforms/vscode/src/__tests__/chat-view-provider.test.ts
+++ b/packages/platforms/vscode/src/__tests__/chat-view-provider.test.ts
@@ -58,6 +58,7 @@ function createMockAgent(): {
     getProviders: vi.fn().mockResolvedValue({ providers: [], default: {} }),
     listAllProviders: vi.fn().mockResolvedValue({ all: [], default: {}, connected: [] }),
     getAgents: vi.fn().mockResolvedValue([]),
+    getSkills: vi.fn().mockResolvedValue([]),
     getChildSessions: vi.fn().mockResolvedValue([]),
     replyPermission: vi.fn().mockResolvedValue(undefined),
     getSessionDiff: vi.fn().mockResolvedValue([]),
@@ -499,12 +500,14 @@ describe("ChatViewProvider", () => {
         model: { providerID: "anthropic", modelID: "claude-4" },
         files: [{ filePath: "a.ts", fileName: "a.ts" }],
         agent: "reviewer",
+        skill: "coding-guidelines",
       });
 
       expect(mockAgent.sendMessage).toHaveBeenCalledWith("sess-1", "Hello", {
         model: { providerID: "anthropic", modelID: "claude-4" },
         files: [{ filePath: "a.ts", fileName: "a.ts" }],
         agent: "reviewer",
+        skill: "coding-guidelines",
       });
     });
   });
@@ -906,6 +909,18 @@ describe("ChatViewProvider", () => {
       await sendMessage({ type: "getAgents" });
 
       expect(postMessage).toHaveBeenCalledWith({ type: "agents", agents });
+    });
+  });
+
+  describe("getSkills", () => {
+    it("should send skills message", async () => {
+      const skills = [{ name: "coding-guidelines" }];
+      mockAgent.getSkills.mockResolvedValue(skills as never);
+
+      const { postMessage, sendMessage } = setupProvider(mockAgent);
+      await sendMessage({ type: "getSkills" });
+
+      expect(postMessage).toHaveBeenCalledWith({ type: "skills", skills });
     });
   });
 

--- a/packages/platforms/vscode/src/chat-view-provider.ts
+++ b/packages/platforms/vscode/src/chat-view-provider.ts
@@ -103,6 +103,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
           files: message.files,
           agent: message.agent,
           primaryAgent: message.primaryAgent,
+          skill: message.skill,
         });
         break;
       }
@@ -264,6 +265,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       case "getAgents": {
         const agents = await this.agent.getAgents();
         this.postMessage({ type: "agents", agents });
+        break;
+      }
+      case "getSkills": {
+        const skills = await this.agent.getSkills();
+        this.postMessage({ type: "skills", skills });
         break;
       }
       case "shareSession": {

--- a/packages/platforms/vscode/webview/App.tsx
+++ b/packages/platforms/vscode/webview/App.tsx
@@ -1,4 +1,4 @@
-import type { AgentEvent, AgentInfo, ChatSession, TodoItem } from "@opencodegui/core";
+import type { AgentEvent, AgentInfo, ChatSession, SkillInfo, TodoItem } from "@opencodegui/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { EmptyState } from "./components/molecules/EmptyState";
 import { FileChangesHeader } from "./components/molecules/FileChangesHeader";
@@ -47,6 +47,7 @@ export function App() {
   const [todos, setTodos] = useState<TodoItem[]>([]);
   const [childSessions, setChildSessions] = useState<ChatSession[]>([]);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
+  const [skills, setSkills] = useState<SkillInfo[]>([]);
   const [selectedPrimaryAgent, setSelectedPrimaryAgent] = useState<string | null>(null);
   const [difitAvailable, setDifitAvailable] = useState(false);
   const [openCodePaths, setOpenCodePaths] = useState<{
@@ -208,6 +209,10 @@ export function App() {
           });
           break;
         }
+        case "skills": {
+          setSkills(data.skills);
+          break;
+        }
         case "difitAvailable": {
           setDifitAvailable(data.available);
           break;
@@ -218,6 +223,7 @@ export function App() {
     postMessage({ type: "ready" });
     postMessage({ type: "getOpenEditors" });
     postMessage({ type: "getAgents" });
+    postMessage({ type: "getSkills" });
     return () => window.removeEventListener("message", handler);
   }, [
     session.activeSession?.id,
@@ -236,7 +242,7 @@ export function App() {
   // Cross-cutting action handlers (span multiple hooks)
 
   const handleSend = useCallback(
-    (text: string, files: FileAttachment[], agent?: string, primaryAgent?: string) => {
+    (text: string, files: FileAttachment[], agent?: string, primaryAgent?: string, skill?: string) => {
       if (!session.activeSession) return;
       postMessage({
         type: "sendMessage",
@@ -246,6 +252,7 @@ export function App() {
         files: files.length > 0 ? files : undefined,
         agent,
         primaryAgent,
+        skill,
       });
     },
     [session.activeSession, prov.selectedModel],
@@ -538,6 +545,7 @@ export function App() {
                   soundSettings={sound.soundSettings}
                   onSoundSettingChange={sound.handleSoundSettingChange}
                   agents={agents}
+                  skills={skills}
                 />
               )}
             </>

--- a/packages/platforms/vscode/webview/__tests__/components/molecules/FileAttachmentBar.test.tsx
+++ b/packages/platforms/vscode/webview/__tests__/components/molecules/FileAttachmentBar.test.tsx
@@ -30,6 +30,10 @@ const defaultProps = {
   selectedAgent: null,
   onSelectAgent: vi.fn(),
   onClearAgent: vi.fn(),
+  skills: [] as any[],
+  selectedSkill: null,
+  onSelectSkill: vi.fn(),
+  onClearSkill: vi.fn(),
   isShellMode: false,
   onToggleShellMode: vi.fn(),
   onDisableShellMode: vi.fn(),
@@ -105,13 +109,20 @@ describe("FileAttachmentBar", () => {
       expect(container.querySelector(".pickerDropdown")).toBeInTheDocument();
     });
 
-    // renders three sections: Files, Agents, Shell Mode
-    it("3 つのセクション（Files, Agents, Shell Mode）を表示すること", () => {
+    // renders four sections: Files, Agents, Skills, Shell Mode
+    it("4 つのセクション（Files, Agents, Skills, Shell Mode）を表示すること", () => {
       render(
-        <FileAttachmentBar {...defaultProps} showFilePicker={true} pickerFiles={[file1]} agents={[agent1, agent2]} />,
+        <FileAttachmentBar
+          {...defaultProps}
+          showFilePicker={true}
+          pickerFiles={[file1]}
+          agents={[agent1, agent2]}
+          skills={[{ name: "coding-guidelines", description: "guides" }] as any}
+        />,
       );
       expect(screen.getByText("Files")).toBeInTheDocument();
       expect(screen.getByText("Sub-agents")).toBeInTheDocument();
+      expect(screen.getByText("Skills")).toBeInTheDocument();
       expect(screen.getByText("Shell Mode")).toBeInTheDocument();
     });
   });
@@ -161,7 +172,7 @@ describe("FileAttachmentBar", () => {
         />,
       );
       const disabledSections = container.querySelectorAll(".sectionDisabled");
-      expect(disabledSections.length).toBe(2);
+      expect(disabledSections.length).toBe(3);
     });
 
     // toggle track has toggleOn class

--- a/packages/platforms/vscode/webview/__tests__/components/molecules/SkillPopup.test.tsx
+++ b/packages/platforms/vscode/webview/__tests__/components/molecules/SkillPopup.test.tsx
@@ -1,0 +1,51 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SkillPopup } from "../../../components/molecules/SkillPopup";
+
+function createSkill(name: string, description?: string) {
+  return {
+    name,
+    description,
+    location: `/skills/${name}`,
+  };
+}
+
+describe("SkillPopup", () => {
+  context("スキル一覧がある場合", () => {
+    const skills = [createSkill("coding-guidelines", "Coding skill"), createSkill("manage-task-plan", "Task plan")];
+
+    it("スキル名を表示すること", () => {
+      const { container } = render(
+        <SkillPopup skills={skills} onSelectSkill={vi.fn()} skillPopupRef={{ current: null }} focusedIndex={-1} />,
+      );
+      const titles = container.querySelectorAll(".title");
+      expect(titles[0]?.textContent).toBe("coding-guidelines");
+      expect(titles[1]?.textContent).toBe("manage-task-plan");
+    });
+
+    it("クリックで onSelectSkill を呼ぶこと", async () => {
+      const onSelect = vi.fn();
+      const user = userEvent.setup();
+      const { container } = render(
+        <SkillPopup skills={skills} onSelectSkill={onSelect} skillPopupRef={{ current: null }} focusedIndex={-1} />,
+      );
+      const items = container.querySelectorAll(".root > div");
+      await user.click(items[0]!);
+      expect(onSelect).toHaveBeenCalledWith(skills[0]);
+    });
+  });
+
+  context("focusedIndex が指定された場合", () => {
+    const skills = [createSkill("coding-guidelines", "Coding skill"), createSkill("manage-task-plan", "Task plan")];
+
+    it("対応するアイテムに data-focused 属性が付与されること", () => {
+      const { container } = render(
+        <SkillPopup skills={skills} onSelectSkill={vi.fn()} skillPopupRef={{ current: null }} focusedIndex={1} />,
+      );
+      const items = container.querySelectorAll("[data-focused]");
+      expect(items).toHaveLength(1);
+      expect(items[0]?.getAttribute("data-focused")).toBe("true");
+    });
+  });
+});

--- a/packages/platforms/vscode/webview/__tests__/factories.ts
+++ b/packages/platforms/vscode/webview/__tests__/factories.ts
@@ -152,7 +152,7 @@ export function createAllProvidersData(
   connected: string[] = [],
   all: Array<{ id: string; name: string; models: Record<string, unknown> }> = [],
   defaultModel: Record<string, string> = {},
-) {
+): any {
   return {
     connected,
     all: all.map((p) => ({

--- a/packages/platforms/vscode/webview/__tests__/scenarios/01-initialization.test.tsx
+++ b/packages/platforms/vscode/webview/__tests__/scenarios/01-initialization.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { postMessage } from "../../vscode-api";
 import { createAllProvidersData, createProvider, createSession } from "../factories";
 import { renderApp, sendExtMessage } from "../helpers";
@@ -21,6 +21,12 @@ describe("初期化", () => {
       renderApp();
 
       expect(postMessage).toHaveBeenCalledWith({ type: "getOpenEditors" });
+    });
+
+    it("getSkills を送信すること", () => {
+      renderApp();
+
+      expect(postMessage).toHaveBeenCalledWith({ type: "getSkills" });
     });
   });
 

--- a/packages/platforms/vscode/webview/__tests__/scenarios/21-popup-tab-select.test.tsx
+++ b/packages/platforms/vscode/webview/__tests__/scenarios/21-popup-tab-select.test.tsx
@@ -27,6 +27,19 @@ const testAgents = [
   },
 ] as any;
 
+const testSkills = [
+  {
+    name: "coding-guidelines",
+    description: "Coding skill",
+    location: "/skills/coding-guidelines",
+  },
+  {
+    name: "manage-task-plan",
+    description: "Task plan skill",
+    location: "/skills/manage-task-plan",
+  },
+] as any;
+
 /** ファイル候補付きセットアップ */
 async function setupWithFiles() {
   renderApp();
@@ -47,6 +60,7 @@ async function setupWithFiles() {
     ],
   });
   await sendExtMessage({ type: "agents", agents: testAgents });
+  await sendExtMessage({ type: "skills", skills: testSkills });
   vi.mocked(postMessage).mockClear();
 }
 
@@ -257,6 +271,30 @@ describe("ポップアップの Tab 選択", () => {
       expect(popup?.querySelectorAll(":scope > div")[1]?.getAttribute("data-focused")).toBe("true");
       await user.keyboard("{ArrowUp}");
       expect(popup?.querySelectorAll(":scope > div")[0]?.getAttribute("data-focused")).toBe("true");
+    });
+  });
+
+  context("/ ポップアップで Tab を押した場合", () => {
+    it("先頭のスキルにフォーカスが当たること", async () => {
+      const user = userEvent.setup();
+      const textarea = screen.getByPlaceholderText("Ask OpenCode... (type # to attach files)");
+      await user.type(textarea, "/");
+      await user.keyboard("{Tab}");
+      const popup = document.querySelector("[data-testid='skill-popup']");
+      const items = popup?.querySelectorAll(":scope > div");
+      expect(items?.[0]?.getAttribute("data-focused")).toBe("true");
+    });
+  });
+
+  context("/ ポップアップで Enter を押した場合", () => {
+    it("スキルが選択されポップアップが閉じること", async () => {
+      const user = userEvent.setup();
+      const textarea = screen.getByPlaceholderText("Ask OpenCode... (type # to attach files)");
+      await user.type(textarea, "/");
+      await user.keyboard("{Tab}");
+      await user.keyboard("{Enter}");
+      expect(screen.queryByTestId("skill-popup")).not.toBeInTheDocument();
+      expect(screen.getByText("/coding-guidelines")).toBeInTheDocument();
     });
   });
 });

--- a/packages/platforms/vscode/webview/__tests__/scenarios/23-clip-context-menu.test.tsx
+++ b/packages/platforms/vscode/webview/__tests__/scenarios/23-clip-context-menu.test.tsx
@@ -27,11 +27,20 @@ const testAgents = [
   },
 ] as any;
 
+const testSkills = [
+  {
+    name: "coding-guidelines",
+    description: "Code with project guidelines",
+    location: "/skills/coding-guidelines",
+  },
+] as any;
+
 /** エージェント付きセットアップ */
 async function setupWithAgents() {
   renderApp();
   await sendExtMessage({ type: "activeSession", session: createSession({ id: "s1" }) });
   await sendExtMessage({ type: "agents", agents: testAgents });
+  await sendExtMessage({ type: "skills", skills: testSkills });
   vi.mocked(postMessage).mockClear();
 }
 
@@ -40,6 +49,7 @@ async function setupWithFiles() {
   renderApp();
   await sendExtMessage({ type: "activeSession", session: createSession({ id: "s1" }) });
   await sendExtMessage({ type: "agents", agents: testAgents });
+  await sendExtMessage({ type: "skills", skills: testSkills });
   // openEditors はファイルピッカー表示時に使う
   await sendExtMessage({
     type: "openEditors",
@@ -64,13 +74,14 @@ describe("統合コンテキストメニュー", () => {
       await setupWithAgents();
     });
 
-    // shows file, agent, and shell sections
-    it("ファイル・エージェント・シェルモードの 3 セクションが表示されること", async () => {
+    // shows file, agent, skill, and shell sections
+    it("ファイル・エージェント・スキル・シェルモードの 4 セクションが表示されること", async () => {
       const user = userEvent.setup();
       const clipButton = screen.getByTitle("Add context");
       await user.click(clipButton);
       expect(screen.getByText("Files")).toBeInTheDocument();
       expect(screen.getByText("Sub-agents")).toBeInTheDocument();
+      expect(screen.getByText("Skills")).toBeInTheDocument();
       expect(screen.getByText("Shell Mode")).toBeInTheDocument();
     });
   });
@@ -101,6 +112,34 @@ describe("統合コンテキストメニュー", () => {
           type: "sendMessage",
           text: "Fix the bug",
           agent: "general",
+        }),
+      );
+    });
+  });
+
+  context("統合メニューからスキルを選択した場合", () => {
+    beforeEach(async () => {
+      await setupWithAgents();
+    });
+
+    it("スキルチップが contextBar に表示されること", async () => {
+      const user = userEvent.setup();
+      await user.click(screen.getByTitle("Add context"));
+      await user.click(screen.getByText("coding-guidelines"));
+      expect(screen.getByText("/coding-guidelines")).toBeInTheDocument();
+    });
+
+    it("送信時に skill が含まれること", async () => {
+      const user = userEvent.setup();
+      await user.click(screen.getByTitle("Add context"));
+      await user.click(screen.getByText("coding-guidelines"));
+      const textarea = screen.getByPlaceholderText("Ask OpenCode... (type # to attach files)");
+      await user.type(textarea, "Fix the bug{Enter}");
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "sendMessage",
+          text: "Fix the bug",
+          skill: "coding-guidelines",
         }),
       );
     });

--- a/packages/platforms/vscode/webview/components/molecules/FileAttachmentBar/FileAttachmentBar.module.css
+++ b/packages/platforms/vscode/webview/components/molecules/FileAttachmentBar/FileAttachmentBar.module.css
@@ -268,3 +268,38 @@
 .agentChipClear:hover {
   opacity: 1;
 }
+
+.skillChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 6px;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--vscode-terminal-ansiGreen, #98c379);
+  background-color: var(--vscode-input-background);
+  border: 1px solid var(--vscode-terminal-ansiGreen, #98c379);
+  border-radius: 4px;
+}
+
+.skillChipName {
+  font-weight: 600;
+}
+
+.skillChipClear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: inherit;
+  opacity: 0.7;
+}
+
+.skillChipClear:hover {
+  opacity: 1;
+}

--- a/packages/platforms/vscode/webview/components/molecules/FileAttachmentBar/FileAttachmentBar.tsx
+++ b/packages/platforms/vscode/webview/components/molecules/FileAttachmentBar/FileAttachmentBar.tsx
@@ -1,9 +1,9 @@
-import type { AgentInfo } from "@opencodegui/core";
+import type { AgentInfo, SkillInfo } from "@opencodegui/core";
 import { useLocale } from "../../../locales";
 import { getFileIcon } from "../../../utils/file-icons";
 import type { FileAttachment } from "../../../vscode-api";
 import { IconButton } from "../../atoms/IconButton";
-import { AgentIcon, ClipIcon, CloseIcon, PlusIcon, TerminalIcon } from "../../atoms/icons";
+import { AgentIcon, ClipIcon, CloseIcon, GearIcon, PlusIcon, TerminalIcon } from "../../atoms/icons";
 import { ListItem } from "../../atoms/ListItem";
 import styles from "./FileAttachmentBar.module.css";
 
@@ -23,6 +23,10 @@ type Props = {
   selectedAgent: AgentInfo | null;
   onSelectAgent: (agent: AgentInfo) => void;
   onClearAgent: () => void;
+  skills: SkillInfo[];
+  selectedSkill: SkillInfo | null;
+  onSelectSkill: (skill: SkillInfo) => void;
+  onClearSkill: () => void;
   isShellMode: boolean;
   onToggleShellMode: () => void;
   onDisableShellMode: () => void;
@@ -44,6 +48,10 @@ export function FileAttachmentBar({
   selectedAgent,
   onSelectAgent,
   onClearAgent,
+  skills,
+  selectedSkill,
+  onSelectSkill,
+  onClearSkill,
   isShellMode,
   onToggleShellMode,
   onDisableShellMode,
@@ -116,6 +124,28 @@ export function FileAttachmentBar({
               </div>
             </div>
 
+            {/* スキルセクション */}
+            <div className={isShellMode ? styles.sectionDisabled : undefined}>
+              <div className={styles.sectionDivider} />
+              <div className={styles.sectionHeader}>{t["input.section.skills"]}</div>
+              <div className={styles.pickerList}>
+                {skills.length > 0 ? (
+                  skills.map((skill) => (
+                    <ListItem
+                      key={skill.name}
+                      title={skill.name}
+                      description={skill.description}
+                      icon={<GearIcon width={14} height={14} />}
+                      onClick={() => onSelectSkill(skill)}
+                      focused={selectedSkill?.name === skill.name}
+                    />
+                  ))
+                ) : (
+                  <div className={styles.pickerEmpty}>{t["input.noSkills"]}</div>
+                )}
+              </div>
+            </div>
+
             {/* シェルモードセクション */}
             <div className={styles.sectionDivider} />
             <div className={styles.sectionHeader}>{t["input.section.shell"]}</div>
@@ -145,6 +175,15 @@ export function FileAttachmentBar({
           <AgentIcon />
           <span className={styles.agentChipName}>@{selectedAgent.name}</span>
           <button type="button" className={styles.agentChipClear} onClick={onClearAgent}>
+            <CloseIcon width={12} height={12} />
+          </button>
+        </div>
+      )}
+      {selectedSkill && (
+        <div className={styles.skillChip}>
+          <GearIcon width={14} height={14} />
+          <span className={styles.skillChipName}>/{selectedSkill.name}</span>
+          <button type="button" className={styles.skillChipClear} onClick={onClearSkill}>
             <CloseIcon width={12} height={12} />
           </button>
         </div>

--- a/packages/platforms/vscode/webview/components/molecules/SkillPopup/SkillPopup.module.css
+++ b/packages/platforms/vscode/webview/components/molecules/SkillPopup/SkillPopup.module.css
@@ -1,0 +1,21 @@
+.root {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 4px;
+  min-width: 240px;
+  max-width: 360px;
+  max-height: 200px;
+  overflow-y: auto;
+  background-color: var(--vscode-quickInput-background);
+  border: 1px solid var(--vscode-dropdown-border);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  z-index: 100;
+}
+
+.empty {
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+}

--- a/packages/platforms/vscode/webview/components/molecules/SkillPopup/SkillPopup.tsx
+++ b/packages/platforms/vscode/webview/components/molecules/SkillPopup/SkillPopup.tsx
@@ -1,0 +1,35 @@
+import type { SkillInfo } from "@opencodegui/core";
+import { useLocale } from "../../../locales";
+import { GearIcon } from "../../atoms/icons";
+import { ListItem } from "../../atoms/ListItem";
+import styles from "./SkillPopup.module.css";
+
+type Props = {
+  skills: SkillInfo[];
+  onSelectSkill: (skill: SkillInfo) => void;
+  skillPopupRef: React.RefObject<HTMLDivElement | null>;
+  focusedIndex: number;
+};
+
+export function SkillPopup({ skills, onSelectSkill, skillPopupRef, focusedIndex }: Props) {
+  const t = useLocale();
+
+  return (
+    <div className={styles.root} ref={skillPopupRef} data-testid="skill-popup">
+      {skills.length > 0 ? (
+        skills.map((skill, i) => (
+          <ListItem
+            key={skill.name}
+            title={skill.name}
+            description={skill.description}
+            icon={<GearIcon width={14} height={14} />}
+            onClick={() => onSelectSkill(skill)}
+            focused={i === focusedIndex}
+          />
+        ))
+      ) : (
+        <div className={styles.empty}>{t["input.noSkills"]}</div>
+      )}
+    </div>
+  );
+}

--- a/packages/platforms/vscode/webview/components/molecules/SkillPopup/index.ts
+++ b/packages/platforms/vscode/webview/components/molecules/SkillPopup/index.ts
@@ -1,0 +1,1 @@
+export { SkillPopup } from "./SkillPopup";

--- a/packages/platforms/vscode/webview/components/organisms/InputArea/InputArea.tsx
+++ b/packages/platforms/vscode/webview/components/organisms/InputArea/InputArea.tsx
@@ -1,4 +1,11 @@
-import type { AgentInfo, ProviderInfo, SoundEventSetting, SoundEventType, SoundSettings } from "@opencodegui/core";
+import type {
+  AgentInfo,
+  ProviderInfo,
+  SkillInfo,
+  SoundEventSetting,
+  SoundEventType,
+  SoundSettings,
+} from "@opencodegui/core";
 import { type KeyboardEvent, useCallback, useEffect, useRef, useState } from "react";
 import { useClickOutside } from "../../../hooks/useClickOutside";
 import { useInputHistory } from "../../../hooks/useInputHistory";
@@ -14,11 +21,12 @@ import { AgentSelector } from "../../molecules/AgentSelector";
 import { FileAttachmentBar } from "../../molecules/FileAttachmentBar";
 import { HashFilePopup } from "../../molecules/HashFilePopup";
 import { ModelSelector } from "../../molecules/ModelSelector";
+import { SkillPopup } from "../../molecules/SkillPopup";
 import { ToolConfigPanel } from "../../organisms/ToolConfigPanel";
 import styles from "./InputArea.module.css";
 
 type Props = {
-  onSend: (text: string, files: FileAttachment[], agent?: string, primaryAgent?: string) => void;
+  onSend: (text: string, files: FileAttachment[], agent?: string, primaryAgent?: string, skill?: string) => void;
   onShellExecute: (command: string) => void;
   onAbort: () => void;
   isBusy: boolean;
@@ -41,6 +49,7 @@ type Props = {
   soundSettings: SoundSettings;
   onSoundSettingChange: (eventType: SoundEventType, setting: Partial<SoundEventSetting>) => void;
   agents: AgentInfo[];
+  skills: SkillInfo[];
 };
 
 export function InputArea({
@@ -67,6 +76,7 @@ export function InputArea({
   soundSettings,
   onSoundSettingChange,
   agents,
+  skills,
 }: Props) {
   const t = useLocale();
   const [text, setText] = useState("");
@@ -85,16 +95,24 @@ export function InputArea({
     startIndex: -1,
   });
   const [atQuery, setAtQuery] = useState("");
+  const [slashTrigger, setSlashTrigger] = useState<{ active: boolean; startIndex: number }>({
+    active: false,
+    startIndex: -1,
+  });
+  const [slashQuery, setSlashQuery] = useState("");
   const [selectedAgent, setSelectedAgent] = useState<AgentInfo | null>(null);
+  const [selectedSkill, setSelectedSkill] = useState<SkillInfo | null>(null);
   const [isShellMode, setIsShellMode] = useState(false);
   // ポップアップ内のフォーカス位置（-1 = フォーカスなし）
   const [hashFocusedIndex, setHashFocusedIndex] = useState(-1);
   const [atFocusedIndex, setAtFocusedIndex] = useState(-1);
+  const [slashFocusedIndex, setSlashFocusedIndex] = useState(-1);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const composingRef = useRef(false);
   const filePickerRef = useRef<HTMLDivElement>(null);
   const hashPopupRef = useRef<HTMLDivElement>(null);
   const agentPopupRef = useRef<HTMLDivElement>(null);
+  const skillPopupRef = useRef<HTMLDivElement>(null);
   const inputHistory = useInputHistory();
   // 履歴テキスト適用時は onChange が走るが resetNavigation を呼ばないようにするフラグ
   const applyingHistoryRef = useRef(false);
@@ -183,6 +201,16 @@ export function InputArea({
     atTrigger.active,
   );
 
+  useClickOutside(
+    [skillPopupRef, textareaRef],
+    () => {
+      setSlashTrigger({ active: false, startIndex: -1 });
+      setSlashQuery("");
+      setSlashFocusedIndex(-1);
+    },
+    slashTrigger.active,
+  );
+
   // # トリガー: ワークスペースファイルを検索する
   useEffect(() => {
     if (hashTrigger.active) {
@@ -195,6 +223,7 @@ export function InputArea({
     setIsShellMode(true);
     setAttachedFiles([]);
     setSelectedAgent(null);
+    setSelectedSkill(null);
   }, []);
 
   // シェルモード OFF
@@ -237,6 +266,29 @@ export function InputArea({
     setSelectedAgent(null);
   }, []);
 
+  const selectSkill = useCallback(
+    (skill: SkillInfo) => {
+      setSelectedSkill(skill);
+      setIsShellMode(false);
+      if (slashTrigger.active) {
+        setText((prev) => {
+          const before = prev.slice(0, slashTrigger.startIndex);
+          const after = prev.slice(slashTrigger.startIndex + 1 + slashQuery.length);
+          return before + after;
+        });
+      }
+      setSlashTrigger({ active: false, startIndex: -1 });
+      setSlashQuery("");
+      setSlashFocusedIndex(-1);
+      textareaRef.current?.focus();
+    },
+    [slashQuery, slashTrigger],
+  );
+
+  const clearSkill = useCallback(() => {
+    setSelectedSkill(null);
+  }, []);
+
   const handleSend = useCallback(() => {
     const trimmed = text.trim();
     if (!trimmed) return;
@@ -245,11 +297,12 @@ export function InputArea({
     if (isShellMode) {
       onShellExecute(trimmed);
     } else {
-      onSend(trimmed, attachedFiles, selectedAgent?.name, selectedPrimaryAgent ?? undefined);
+      onSend(trimmed, attachedFiles, selectedAgent?.name, selectedPrimaryAgent ?? undefined, selectedSkill?.name);
     }
     setText("");
     setAttachedFiles([]);
     setSelectedAgent(null);
+    setSelectedSkill(null);
     setIsShellMode(false);
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
@@ -260,6 +313,7 @@ export function InputArea({
     onSend,
     onShellExecute,
     selectedAgent?.name,
+    selectedSkill?.name,
     isShellMode,
     inputHistory,
     selectedPrimaryAgent,
@@ -284,6 +338,9 @@ export function InputArea({
   const filteredAgents = atQuery
     ? subagents.filter((a) => a.name.toLowerCase().includes(atQuery.toLowerCase())).slice(0, 10)
     : subagents.slice(0, 10);
+  const filteredSkills = slashQuery
+    ? skills.filter((skill) => skill.name.toLowerCase().includes(slashQuery.toLowerCase())).slice(0, 10)
+    : skills.slice(0, 10);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -299,6 +356,12 @@ export function InputArea({
         setAtTrigger({ active: false, startIndex: -1 });
         setAtQuery("");
         setAtFocusedIndex(-1);
+        return;
+      }
+      if (e.key === "Escape" && slashTrigger.active) {
+        setSlashTrigger({ active: false, startIndex: -1 });
+        setSlashQuery("");
+        setSlashFocusedIndex(-1);
         return;
       }
 
@@ -342,6 +405,24 @@ export function InputArea({
           e.preventDefault();
           selectAgent(filteredAgents[atFocusedIndex]);
           setAtFocusedIndex(-1);
+          return;
+        }
+      }
+
+      if (slashTrigger.active && filteredSkills.length > 0) {
+        if (e.key === "Tab" || e.key === "ArrowDown") {
+          e.preventDefault();
+          setSlashFocusedIndex((prev) => (prev + 1) % filteredSkills.length);
+          return;
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setSlashFocusedIndex((prev) => (prev <= 0 ? filteredSkills.length - 1 : prev - 1));
+          return;
+        }
+        if (e.key === "Enter" && !e.shiftKey && !composingRef.current && slashFocusedIndex >= 0) {
+          e.preventDefault();
+          selectSkill(filteredSkills[slashFocusedIndex]);
           return;
         }
       }
@@ -417,6 +498,11 @@ export function InputArea({
           setAtQuery("");
           setAtFocusedIndex(-1);
         }
+        if (slashTrigger.active) {
+          setSlashTrigger({ active: false, startIndex: -1 });
+          setSlashQuery("");
+          setSlashFocusedIndex(-1);
+        }
         handleSend();
       }
     },
@@ -427,10 +513,14 @@ export function InputArea({
       atTrigger.active,
       hashFocusedIndex,
       atFocusedIndex,
+      slashTrigger.active,
+      slashFocusedIndex,
       hashFiles,
       filteredAgents,
+      filteredSkills,
       addFile,
       selectAgent,
+      selectSkill,
       text,
       inputHistory,
     ],
@@ -478,6 +568,14 @@ export function InputArea({
           setAtQuery("");
           return;
         }
+        if (
+          addedChar === "/" &&
+          (cursorPos === 1 || newText[cursorPos - 2] === " " || newText[cursorPos - 2] === "\n")
+        ) {
+          setSlashTrigger({ active: true, startIndex: cursorPos - 1 });
+          setSlashQuery("");
+          return;
+        }
       }
 
       // # トリガーがアクティブなら、クエリを更新する
@@ -508,8 +606,20 @@ export function InputArea({
           setAtFocusedIndex(-1);
         }
       }
+
+      if (slashTrigger.active) {
+        const queryPart = newText.slice(slashTrigger.startIndex + 1, cursorPos);
+        if (/\s/.test(queryPart) || cursorPos <= slashTrigger.startIndex) {
+          setSlashTrigger({ active: false, startIndex: -1 });
+          setSlashQuery("");
+          setSlashFocusedIndex(-1);
+        } else {
+          setSlashQuery(queryPart);
+          setSlashFocusedIndex(-1);
+        }
+      }
     },
-    [text, hashTrigger, atTrigger, isShellMode, enableShellMode, inputHistory],
+    [text, hashTrigger, atTrigger, slashTrigger, isShellMode, enableShellMode, inputHistory],
   );
 
   const handleInput = useCallback(() => {
@@ -552,6 +662,10 @@ export function InputArea({
               selectedAgent={selectedAgent}
               onSelectAgent={selectAgent}
               onClearAgent={clearAgent}
+              skills={skills}
+              selectedSkill={selectedSkill}
+              onSelectSkill={selectSkill}
+              onClearSkill={clearSkill}
               isShellMode={isShellMode}
               onToggleShellMode={toggleShellMode}
               onDisableShellMode={disableShellMode}
@@ -593,6 +707,14 @@ export function InputArea({
               onSelectAgent={selectAgent}
               agentPopupRef={agentPopupRef}
               focusedIndex={atFocusedIndex}
+            />
+          )}
+          {slashTrigger.active && (
+            <SkillPopup
+              skills={filteredSkills}
+              onSelectSkill={selectSkill}
+              skillPopupRef={skillPopupRef}
+              focusedIndex={slashFocusedIndex}
             />
           )}
         </div>

--- a/packages/platforms/vscode/webview/locales/en.ts
+++ b/packages/platforms/vscode/webview/locales/en.ts
@@ -143,10 +143,12 @@ export const en = {
   // Context menu sections
   "input.section.files": "Files",
   "input.section.agents": "Sub-agents",
+  "input.section.skills": "Skills",
   "input.section.shell": "Shell Mode",
 
   // AgentMention
   "input.noAgents": "No sub-agents available",
+  "input.noSkills": "No skills available",
 } as const;
 
 export type LocaleSchema = {

--- a/packages/platforms/vscode/webview/locales/ja.ts
+++ b/packages/platforms/vscode/webview/locales/ja.ts
@@ -145,8 +145,10 @@ export const ja: LocaleSchema = {
   // Context menu sections
   "input.section.files": "ファイル",
   "input.section.agents": "サブエージェント",
+  "input.section.skills": "スキル",
   "input.section.shell": "シェルモード",
 
   // AgentMention
   "input.noAgents": "利用可能なサブエージェントがありません",
+  "input.noSkills": "利用可能なスキルがありません",
 };


### PR DESCRIPTION
## Summary

VS Code のチャット入力で、OpenCode の skill を 1 件だけ明示選択して送れるようにします。
コンテキストメニューだけでなく、入力欄で `/` を打ったときの補完からも skill を選べるようにしています。

## Related Issue

#98

## Changes

- core / host / agent 間で `skill` を受け渡すための型とプロトコルを追加
- OpenCode の skill 一覧を取得し、入力欄のコンテキストバーに選択中 skill のチップを表示
- コンテキストメニューから skill を 1 件選択・解除できる UI を追加
- 入力欄で `/` を入力したときに skill 候補を補完表示し、Tab / Enter で確定できるように追加
- 送信時は選択した skill を synthetic な `/{skill}` text part として先頭に付与
- skill 読み込み、選択、slash 補完、送信 payload を検証するテストを追加・更新

## Checklist

- [ ] `npm run build` passes
- [ ] `npm test` passes